### PR TITLE
chore: update to latest kaniko release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache ca-certificates
 ##    docker build --no-cache -t vela-kaniko:local .    ##
 ##########################################################
 
-FROM gcr.io/kaniko-project/executor:debug-v1.1.0
+FROM gcr.io/kaniko-project/executor:debug-v1.2.0
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
Release notes for version:
https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.2.0