### PR TITLE
chore: upgrade to latest kaniko release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache ca-certificates
 ##    docker build --no-cache -t vela-kaniko:local .    ##
 ##########################################################
 
-FROM gcr.io/kaniko-project/executor:debug-v1.2.0
+FROM gcr.io/kaniko-project/executor:debug-v1.3.0
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
Upgrade Kaniko to the latest release `v1.3.0`

The release notes can be found below:

https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.3.0