### PR TITLE
chore: upgrade kaniko to v1.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache ca-certificates
 ##    docker build --no-cache -t vela-kaniko:local .    ##
 ##########################################################
 
-FROM gcr.io/kaniko-project/executor:debug-v1.3.0
+FROM gcr.io/kaniko-project/executor:debug-v1.5.2
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
This change will upgrade Kaniko to the latest release (`v1.5.2`):

https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.5.2

The release notes can be found below:

https://github.com/GoogleContainerTools/kaniko/blob/master/CHANGELOG.md#v152-release-2021-03-30

