### PR TITLE
fix: debug image path for Kaniko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache ca-certificates
 ##    docker build --no-cache -t vela-kaniko:local .    ##
 ##########################################################
 
-FROM gcr.io/kaniko-project/executor:debug-v1.5.2
+FROM gcr.io/kaniko-project/executor:v1.5.2-debug
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
Between the `v1.3.0` and `v1.5.x` releases, the image path for Kaniko has changed.

This ensures we're adopting the latest standards for the Kaniko images being published:

https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.5.2