### PR TITLE
feat: output kaniko version for troubleshooting

### DIFF
--- a/cmd/vela-kaniko/command.go
+++ b/cmd/vela-kaniko/command.go
@@ -30,3 +30,17 @@ func execCmd(e *exec.Cmd) error {
 
 	return e.Run()
 }
+
+// versionCmd is a helper function to output
+// the client version information.
+func versionCmd() *exec.Cmd {
+	logrus.Trace("creating kaniko version command")
+
+	// variable to store flags for command
+	var flags []string
+
+	// add flag for version kaniko command
+	flags = append(flags, "version")
+
+	return exec.Command(kanikoBin, flags...)
+}

--- a/cmd/vela-kaniko/main.go
+++ b/cmd/vela-kaniko/main.go
@@ -255,9 +255,9 @@ func run(c *cli.Context) error {
 
 	logrus.WithFields(logrus.Fields{
 		"code":     "https://github.com/go-vela/vela-kaniko",
-		"docs":     "https://go-vela.github.io/docs/plugins/registry/docker",
+		"docs":     "https://go-vela.github.io/docs/plugins/registry/pipeline/kaniko",
 		"registry": "https://hub.docker.com/r/target/vela-kaniko",
-	}).Info("Vela Docker Plugin")
+	}).Info("Vela Kaniko Plugin")
 
 	// create the plugin
 	p := &Plugin{

--- a/cmd/vela-kaniko/plugin.go
+++ b/cmd/vela-kaniko/plugin.go
@@ -125,6 +125,12 @@ func (p *Plugin) Exec() error {
 		return err
 	}
 
+	// output the kaniko version for troubleshooting
+	err = execCmd(versionCmd())
+	if err != nil {
+		return err
+	}
+
 	// run kaniko command from plugin configuration
 	err = execCmd(p.Command())
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
 github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
@@ -32,7 +31,6 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
 github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=


### PR DESCRIPTION
This invokes the `version` subcommand for the `kaniko` CLI as a part of the plugin output.

To test this, you can checkout this branch and run the following:

```sh
make build; make docker-build; make docker-test
```

This should lead to output that looks like:

```sh
time="2021-05-07T13:53:05Z" level=info msg="Vela Kaniko Plugin" code="https://github.com/go-vela/vela-kaniko" docs="https://go-vela.github.io/docs/plugins/registry/pipeline/kaniko" registry="https://hub.docker.com/r/target/vela-kaniko"
{
  "canonical": "v0.6.0",
  "major": 0,
  "minor": 6,
  "patch": 0,
  "metadata": {
    "architecture": "amd64",
    "build_date": "2021-05-07T08:52:46Z",
    "compiler": "gc",
    "git_commit": "eeea105fed7fc11bda4b43a00edfc49a5c982968",
    "go_version": "go1.16.3",
    "operating_system": "linux"
  }
}
$ /kaniko/executor version
Kaniko version :  v1.6.0
$ /kaniko/executor --context=/workspace/ --destination=index.docker.io/target/vela-kaniko:latest --label org.opencontainers.image.created=2021-05-07T13:53:05Z --label org.opencontainers.image.url= --label org.opencontainers.image.revision=123abcdefg --label io.vela.build.author= --label io.vela.build.number=0 --label io.vela.build.repo= --label io.vela.build.commit=123abcdefg --label io.vela.build.url= --dockerfile=Dockerfile.example --no-push --verbosity=info
...
```

The important part to pull out of this output is:

```sh
$ /kaniko/executor version
Kaniko version :  v1.6.0
```