### PR TITLE
feat: support insecure registries when pushing & pulling

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -220,6 +220,9 @@ The following parameters are used to configure the image:
 | `tags`          | unique tags of the image                                           | `true`   | `latest`          | `PARAMETER_TAGS`<br>`KANIKO_TAGS`                              |
 | `target`        | set the target build stage for the image                           | `false`  | `N/A`             | `PARAMETER_TARGET`<br>`KANIKO_TARGET`                          |
 | `username`      | user name for communication with the registry                      | `true`   | `N/A`             | `PARAMETER_USERNAME`<br>`KANIKO_USERNAME`<br>`DOCKER_USERNAME` |
+| `insecure_registries` | insecure docker registries to push or pull to/from           | `false`  | `empty slice`     | `PARAMETER_INSECURE_REGISTRIES`<br>`KANIKO_INSECURE_REGISTRIES`|
+| `insecure_pull`       | enable pulling from any insecure registry                    | `false`  | `false`           | `PARAMETER_INSECURE_PULL`<br>`KANIKO_INSECURE_PULL`            |
+| `insecure_push`       | enable pushing to any insecure registry                      | `false`  | `false`           | `PARAMETER_INSECURE_PUSH`<br>`KANIKO_INSECURE_PUSH`            |
 
 ## Template
 

--- a/cmd/vela-kaniko/main.go
+++ b/cmd/vela-kaniko/main.go
@@ -295,7 +295,7 @@ func run(c *cli.Context) error {
 			Username:           c.String("registry.username"),
 			Password:           c.String("registry.password"),
 			PushRetry:          c.Int("registry.push_retry"),
-			InsecureRegistries: c.StringSlice("registry.insecure_registries")
+			InsecureRegistries: c.StringSlice("registry.insecure_registries"),
 		},
 		// repo configuration
 		Repo: &Repo{

--- a/cmd/vela-kaniko/main.go
+++ b/cmd/vela-kaniko/main.go
@@ -168,6 +168,18 @@ func main() {
 			Name:     "registry.insecure_registries",
 			Usage:    "insecure registries to push & pull from",
 		},
+		&cli.BoolFlag{
+			EnvVars:  []string{"PARAMETER_INSECURE_PULL", "KANIKO_INSECURE_PULL"},
+			FilePath: "/vela/parameters/kaniko/insecure_pull,/vela/secrets/kaniko/insecure_pull",
+			Name:     "registry.insecure_pull",
+			Usage:    "enable pulling from insecure registries",
+		},
+		&cli.BoolFlag{
+			EnvVars:  []string{"PARAMETER_INSECURE_PUSH", "KANIKO_INSECURE_PUSH"},
+			FilePath: "/vela/parameters/kaniko/insecure_push,/vela/secrets/kaniko/insecure_push",
+			Name:     "registry.insecure_push",
+			Usage:    "enable pushing to insecure registries",
+		},
 
 		// Repo Flags
 
@@ -296,6 +308,8 @@ func run(c *cli.Context) error {
 			Password:           c.String("registry.password"),
 			PushRetry:          c.Int("registry.push_retry"),
 			InsecureRegistries: c.StringSlice("registry.insecure_registries"),
+			InsecurePull:       c.Bool("registry.insecure_pull"),
+			InsecurePush:       c.Bool("registry.insecure_push"),
 		},
 		// repo configuration
 		Repo: &Repo{

--- a/cmd/vela-kaniko/main.go
+++ b/cmd/vela-kaniko/main.go
@@ -162,6 +162,12 @@ func main() {
 			Name:     "registry.push_retry",
 			Usage:    "number of retries for pushing an image to a remote destination",
 		},
+		&cli.StringSliceFlag{
+			EnvVars:  []string{"PARAMETER_INSECURE_REGISTRIES", "KANIKO_INSECURE_REGISTRIES"},
+			FilePath: "/vela/parameters/kaniko/insecure_registries,/vela/secrets/kaniko/insecure_registries",
+			Name:     "registry.insecure_registries",
+			Usage:    "insecure registries to push & pull from",
+		},
 
 		// Repo Flags
 
@@ -283,12 +289,13 @@ func run(c *cli.Context) error {
 		},
 		// registry configuration
 		Registry: &Registry{
-			DryRun:    c.Bool("registry.dry_run"),
-			Name:      c.String("registry.name"),
-			Mirror:    c.String("registry.mirror"),
-			Username:  c.String("registry.username"),
-			Password:  c.String("registry.password"),
-			PushRetry: c.Int("registry.push_retry"),
+			DryRun:             c.Bool("registry.dry_run"),
+			Name:               c.String("registry.name"),
+			Mirror:             c.String("registry.mirror"),
+			Username:           c.String("registry.username"),
+			Password:           c.String("registry.password"),
+			PushRetry:          c.Int("registry.push_retry"),
+			InsecureRegistries: c.StringSlice("registry.insecure_registries")
 		},
 		// repo configuration
 		Repo: &Repo{

--- a/cmd/vela-kaniko/plugin.go
+++ b/cmd/vela-kaniko/plugin.go
@@ -132,7 +132,7 @@ func (p *Plugin) Command() *exec.Cmd {
 	// check for insecure registries
 	for _, registry := range p.Registry.InsecureRegistries {
 		// add flag to allow push/pull from the insecure registry
-		flags = append(flags, fmt.Sprintf("--insecure-registry %s", registry))
+		flags = append(flags, fmt.Sprintf("--insecure-registry=%s", registry))
 	}
 
 	// add flag for logging verbosity

--- a/cmd/vela-kaniko/plugin.go
+++ b/cmd/vela-kaniko/plugin.go
@@ -129,6 +129,14 @@ func (p *Plugin) Command() *exec.Cmd {
 		flags = append(flags, fmt.Sprintf("--target=%s", p.Image.Target))
 	}
 
+	// check for insecure registries
+	if len(p.Registry.InsecureRegistries) > 0 {
+		for _, registry := range p.Registry.InsecureRegistries {
+			// add flag to allow push/pull from the insecure registry
+			flags = append(flags, fmt.Sprintf("--insecure-registry=%s", registry))
+		}
+	}
+
 	// add flag for logging verbosity
 	flags = append(flags, fmt.Sprintf("--verbosity=%s", logrus.GetLevel()))
 

--- a/cmd/vela-kaniko/plugin.go
+++ b/cmd/vela-kaniko/plugin.go
@@ -130,11 +130,9 @@ func (p *Plugin) Command() *exec.Cmd {
 	}
 
 	// check for insecure registries
-	if len(p.Registry.InsecureRegistries) > 0 {
-		for _, registry := range p.Registry.InsecureRegistries {
-			// add flag to allow push/pull from the insecure registry
-			flags = append(flags, fmt.Sprintf("--insecure-registry %s", registry))
-		}
+	for _, registry := range p.Registry.InsecureRegistries {
+		// add flag to allow push/pull from the insecure registry
+		flags = append(flags, fmt.Sprintf("--insecure-registry %s", registry))
 	}
 
 	// add flag for logging verbosity

--- a/cmd/vela-kaniko/plugin.go
+++ b/cmd/vela-kaniko/plugin.go
@@ -135,6 +135,18 @@ func (p *Plugin) Command() *exec.Cmd {
 		flags = append(flags, fmt.Sprintf("--insecure-registry=%s", registry))
 	}
 
+	// check for insecure pulling
+	if p.Registry.InsecurePull {
+		// add flag to allow pulling from any insecure registry
+		flags = append(flags, "--insecure-pull")
+	}
+
+	// check for insecure pushing
+	if p.Registry.InsecurePush {
+		// add flag to allow pushing to any insecure registry
+		flags = append(flags, "--insecure")
+	}
+
 	// add flag for logging verbosity
 	flags = append(flags, fmt.Sprintf("--verbosity=%s", logrus.GetLevel()))
 

--- a/cmd/vela-kaniko/plugin.go
+++ b/cmd/vela-kaniko/plugin.go
@@ -133,7 +133,7 @@ func (p *Plugin) Command() *exec.Cmd {
 	if len(p.Registry.InsecureRegistries) > 0 {
 		for _, registry := range p.Registry.InsecureRegistries {
 			// add flag to allow push/pull from the insecure registry
-			flags = append(flags, fmt.Sprintf("--insecure-registry=%s", registry))
+			flags = append(flags, fmt.Sprintf("--insecure-registry %s", registry))
 		}
 	}
 

--- a/cmd/vela-kaniko/plugin_test.go
+++ b/cmd/vela-kaniko/plugin_test.go
@@ -131,8 +131,8 @@ func TestDocker_Plugin_Command(t *testing.T) {
 		"--no-push",
 		"--push-retry=1",
 		"--target=foo",
-		"--insecure-registry insecure.docker.local",
-		"--insecure-registry docker.local",
+		"--insecure-registry=insecure.docker.local",
+		"--insecure-registry=docker.local",
 		"--verbosity=info",
 	)
 

--- a/cmd/vela-kaniko/plugin_test.go
+++ b/cmd/vela-kaniko/plugin_test.go
@@ -103,11 +103,12 @@ func TestDocker_Plugin_Command(t *testing.T) {
 			Target:     "foo",
 		},
 		Registry: &Registry{
-			Name:      "index.docker.io",
-			Username:  "octocat",
-			Password:  "superSecretPassword",
-			DryRun:    true,
-			PushRetry: 1,
+			Name:               "index.docker.io",
+			Username:           "octocat",
+			Password:           "superSecretPassword",
+			DryRun:             true,
+			PushRetry:          1,
+			InsecureRegistries: []string{"insecure.docker.local", "docker.local"},
 		},
 		Repo: &Repo{
 			Cache:     true,
@@ -130,6 +131,8 @@ func TestDocker_Plugin_Command(t *testing.T) {
 		"--no-push",
 		"--push-retry=1",
 		"--target=foo",
+		"--insecure-registry insecure.docker.local",
+		"--insecure-registry docker.local",
 		"--verbosity=info",
 	)
 

--- a/cmd/vela-kaniko/plugin_test.go
+++ b/cmd/vela-kaniko/plugin_test.go
@@ -109,6 +109,8 @@ func TestDocker_Plugin_Command(t *testing.T) {
 			DryRun:             true,
 			PushRetry:          1,
 			InsecureRegistries: []string{"insecure.docker.local", "docker.local"},
+			InsecurePull:       true,
+			InsecurePush:       true,
 		},
 		Repo: &Repo{
 			Cache:     true,
@@ -133,6 +135,8 @@ func TestDocker_Plugin_Command(t *testing.T) {
 		"--target=foo",
 		"--insecure-registry=insecure.docker.local",
 		"--insecure-registry=docker.local",
+		"--insecure-pull",
+		"--insecure",
 		"--verbosity=info",
 	)
 

--- a/cmd/vela-kaniko/registry.go
+++ b/cmd/vela-kaniko/registry.go
@@ -41,6 +41,8 @@ type Registry struct {
 	DryRun bool
 	// number of retries for pushing an image to a remote destination
 	PushRetry int
+	// insecure registries to push/pull from
+	InsecureRegistries []string
 }
 
 // Write creates a Docker config.json file for building and publishing the image.

--- a/cmd/vela-kaniko/registry.go
+++ b/cmd/vela-kaniko/registry.go
@@ -43,6 +43,10 @@ type Registry struct {
 	PushRetry int
 	// insecure registries to push/pull from
 	InsecureRegistries []string
+	// enable pulling from any insecure registry
+	InsecurePull bool
+	// enable pushing to any insecure registry
+	InsecurePush bool
 }
 
 // Write creates a Docker config.json file for building and publishing the image.


### PR DESCRIPTION
This adds support to the kaniko plugin to instruct Kaniko to push or pull from insecure (http) docker registries.
This is useful for folks running Vela without a way to secure their registries with SSL and also for "home labbers" might be running Vela at home.

Should close https://github.com/go-vela/community/issues/470

Adds new string-slice parameters:
- PARAMETER_INSECURE_REGISTRIES
- KANIKO_INSECURE_REGISTRIES

With support from loading the value from disc at:
- /vela/parameters/kaniko/insecure_registries
- /vela/secrets/kaniko/insecure_registries

---
While #470 above, notes the 3 command line flags, the [kaniko docs](https://github.com/GoogleContainerTools/kaniko#--insecure-registry) would leave me to believe that if you want to allow pushing and/or pulling from an insecure registry, that just this flag alone would work, although I'm not 100% sure how to fully validate that.  
If all are required, I can certainly edit the PR to include all three.