### PR TITLE
feat: Add ability to set `--customPlatform` flag

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -133,6 +133,19 @@ steps:
       repo: index.docker.io/octocat/hello-world
 ```
 
+Sample of building using a custom platform:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: always
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
++     custom_platform: linux/arm64/v8
+```
+
 ## Secrets
 
 > **NOTE:** Users should refrain from configuring sensitive information in your pipeline in plain text.
@@ -220,6 +233,7 @@ The following parameters are used to configure the image:
 | `tags`          | unique tags of the image                                           | `true`   | `latest`          | `PARAMETER_TAGS`<br>`KANIKO_TAGS`                              |
 | `target`        | set the target build stage for the image                           | `false`  | `N/A`             | `PARAMETER_TARGET`<br>`KANIKO_TARGET`                          |
 | `username`      | user name for communication with the registry                      | `true`   | `N/A`             | `PARAMETER_USERNAME`<br>`KANIKO_USERNAME`<br>`DOCKER_USERNAME` |
+| `custom_platform`     | set the custom platform for the image                        | `false`  | `N/A`             | `PARAMETER_CUSTOM_PLATFORM`<br>`KANIKO_CUSTOM_PLATFORM`        |
 | `insecure_registries` | insecure docker registries to push or pull to/from           | `false`  | `empty slice`     | `PARAMETER_INSECURE_REGISTRIES`<br>`KANIKO_INSECURE_REGISTRIES`|
 | `insecure_pull`       | enable pulling from any insecure registry                    | `false`  | `false`           | `PARAMETER_INSECURE_PULL`<br>`KANIKO_INSECURE_PULL`            |
 | `insecure_push`       | enable pushing to any insecure registry                      | `false`  | `false`           | `PARAMETER_INSECURE_PUSH`<br>`KANIKO_INSECURE_PUSH`            |

--- a/cmd/vela-kaniko/image.go
+++ b/cmd/vela-kaniko/image.go
@@ -20,6 +20,8 @@ type Image struct {
 	Dockerfile string
 	// build stage to target for image
 	Target string
+	// custom platform for image
+	CustomPlatform string
 }
 
 // Validate verifies the Image is properly configured.

--- a/cmd/vela-kaniko/main.go
+++ b/cmd/vela-kaniko/main.go
@@ -122,6 +122,12 @@ func main() {
 			Name:     "image.target",
 			Usage:    "build stage to target for image",
 		},
+		&cli.StringFlag{
+			EnvVars:  []string{"PARAMETER_CUSTOM_PLATFORM", "KANIKO_CUSTOM_PLATFORM"},
+			FilePath: "/vela/parameters/kaniko/custom_platform,/vela/secrets/kaniko/custom_platform",
+			Name:     "image.custom_platform",
+			Usage:    "custom platform for the image",
+		},
 
 		// Registry Flags
 
@@ -294,10 +300,11 @@ func run(c *cli.Context) error {
 		},
 		// image configuration
 		Image: &Image{
-			Args:       c.StringSlice("image.build_args"),
-			Context:    c.String("image.context"),
-			Dockerfile: c.String("image.dockerfile"),
-			Target:     c.String("image.target"),
+			Args:           c.StringSlice("image.build_args"),
+			Context:        c.String("image.context"),
+			Dockerfile:     c.String("image.dockerfile"),
+			Target:         c.String("image.target"),
+			CustomPlatform: c.String("image.custom_platform"),
 		},
 		// registry configuration
 		Registry: &Registry{

--- a/cmd/vela-kaniko/plugin.go
+++ b/cmd/vela-kaniko/plugin.go
@@ -129,6 +129,12 @@ func (p *Plugin) Command() *exec.Cmd {
 		flags = append(flags, fmt.Sprintf("--target=%s", p.Image.Target))
 	}
 
+	// check if image custom platform is set
+	if len(p.Image.CustomPlatform) > 0 {
+		// add requested customPlatform flag
+		flags = append(flags, fmt.Sprintf("--customPlatform=%s", p.Image.CustomPlatform))
+	}
+
 	// check for insecure registries
 	for _, registry := range p.Registry.InsecureRegistries {
 		// add flag to allow push/pull from the insecure registry

--- a/cmd/vela-kaniko/plugin_test.go
+++ b/cmd/vela-kaniko/plugin_test.go
@@ -423,10 +423,10 @@ func TestDocker_Plugin_Command_CustomPlatform(t *testing.T) {
 			Tag:   "v0.0.0",
 		},
 		Image: &Image{
-			Args:       []string{"foo=bar"},
-			Context:    ".",
-			Dockerfile: "Dockerfile",
-			Target:     "foo",
+			Args:           []string{"foo=bar"},
+			Context:        ".",
+			Dockerfile:     "Dockerfile",
+			Target:         "foo",
 			CustomPlatform: "linux/arm64/v8",
 		},
 		Registry: &Registry{

--- a/cmd/vela-kaniko/plugin_test.go
+++ b/cmd/vela-kaniko/plugin_test.go
@@ -414,6 +414,68 @@ func TestDocker_Plugin_Command_NoDryRun(t *testing.T) {
 	}
 }
 
+func TestDocker_Plugin_Command_CustomPlatform(t *testing.T) {
+	// setup types
+	p := &Plugin{
+		Build: &Build{
+			Event: "tag",
+			Sha:   "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			Tag:   "v0.0.0",
+		},
+		Image: &Image{
+			Args:       []string{"foo=bar"},
+			Context:    ".",
+			Dockerfile: "Dockerfile",
+			Target:     "foo",
+			CustomPlatform: "linux/arm64/v8",
+		},
+		Registry: &Registry{
+			Name:               "index.docker.io",
+			Username:           "octocat",
+			Password:           "superSecretPassword",
+			DryRun:             true,
+			PushRetry:          1,
+			InsecureRegistries: []string{"insecure.docker.local", "docker.local"},
+			InsecurePull:       true,
+			InsecurePush:       true,
+		},
+		Repo: &Repo{
+			Cache:     true,
+			CacheName: "index.docker.io/target/vela-kaniko",
+			Name:      "index.docker.io/target/vela-kaniko",
+			Tags:      []string{"latest"},
+			AutoTag:   true,
+		},
+	}
+
+	want := exec.Command(
+		kanikoBin,
+		"--build-arg=foo=bar",
+		"--cache",
+		"--cache-repo=index.docker.io/target/vela-kaniko",
+		"--context=.",
+		"--destination=index.docker.io/target/vela-kaniko:latest",
+		"--destination=index.docker.io/target/vela-kaniko:v0.0.0",
+		"--dockerfile=Dockerfile",
+		"--no-push",
+		"--push-retry=1",
+		"--target=foo",
+		"--customPlatform=linux/arm64/v8",
+		"--insecure-registry=insecure.docker.local",
+		"--insecure-registry=docker.local",
+		"--insecure-pull",
+		"--insecure",
+		"--verbosity=info",
+	)
+
+	// run test
+	got := p.Command()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Command is %v, want %v", got, want)
+	}
+}
+
 func TestDocker_Plugin_Validate(t *testing.T) {
 	// setup types
 	p := &Plugin{


### PR DESCRIPTION
Kaniko supports a `--customPlatform` flag to allow creation of images
with a different platform than the default, which is a platform derived
from the build host.

The `--customPlatform` feature doesn't provide any cross-compilation
support by itself, and only platforms which the underlying build host
is able to provide will work correctly.

This commit provides a `custom_platform` plugin parameter which,
when supplied, will provide a value for the `--customPlatform`
argument for `/kaniko/executor`. There is no attempt to verify that
the platform requested is supported by the build host.

Should close go-vela/community#477

Example:
```
  steps:
    - name: publish_hello-world_amd64
      image: vela-plugins/kaniko:vCustomPlatform
      pull: always
      parameters:
        repo: vela/hello-world
        custom_platform: linux/amd64
        tags:
          - latest_linux_amd64
    - name: publish_hello-world_arm64
      image: vela-plugins/kaniko:vCustomPlatform
      pull: always
      parameters:
        repo: vela/hello-world
        custom_platform: linux/arm64/v8
        tags:
          - latest_linux_arm64_v8
```