### PR TITLE
fix: configure repo tags before validation

### DIFF
--- a/cmd/vela-kaniko/build.go
+++ b/cmd/vela-kaniko/build.go
@@ -50,14 +50,6 @@ func (b *Build) Validate() error {
 		}
 	}
 
-	// check if tag is provided
-	if len(b.Tag) > 0 {
-		// check tag value for valid docker tag syntax
-		if !tagRegexp.MatchString(b.Tag) {
-			return fmt.Errorf(errTagValidation, b.Tag)
-		}
-	}
-
 	return nil
 }
 

--- a/cmd/vela-kaniko/build_test.go
+++ b/cmd/vela-kaniko/build_test.go
@@ -60,17 +60,3 @@ func TestDocker_Build_Validate_InvalidSnapshotMode(t *testing.T) {
 		t.Errorf("Validate should have returned err")
 	}
 }
-
-func TestDocker_Build_Validate_InvalidTag(t *testing.T) {
-	// setup types
-	b := &Build{
-		Event: "push",
-		Sha:   "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
-		Tag:   "-v0.0.0",
-	}
-
-	err := b.Validate()
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}

--- a/cmd/vela-kaniko/main.go
+++ b/cmd/vela-kaniko/main.go
@@ -343,6 +343,19 @@ func run(c *cli.Context) error {
 		},
 	}
 
+	// check if repo auto tagging is enabled
+	if p.Repo.AutoTag {
+		// check what build event was provided
+		switch p.Build.Event {
+		case "tag":
+			// add build tag to list of repo tags
+			p.Repo.Tags = append(p.Repo.Tags, p.Build.Tag)
+		default:
+			// add build sha to list of repo tags
+			p.Repo.Tags = append(p.Repo.Tags, p.Build.Sha)
+		}
+	}
+
 	// validate the plugin
 	err := p.Validate()
 	if err != nil {

--- a/cmd/vela-kaniko/main.go
+++ b/cmd/vela-kaniko/main.go
@@ -345,7 +345,7 @@ func run(c *cli.Context) error {
 
 	// check if repo auto tagging is enabled
 	if p.Repo.AutoTag {
-		p.Repo.ConfigureAutoTag(p.Build)
+		p.Repo.ConfigureAutoTagBuildTags(p.Build)
 	}
 
 	// validate the plugin

--- a/cmd/vela-kaniko/main.go
+++ b/cmd/vela-kaniko/main.go
@@ -345,15 +345,7 @@ func run(c *cli.Context) error {
 
 	// check if repo auto tagging is enabled
 	if p.Repo.AutoTag {
-		// check what build event was provided
-		switch p.Build.Event {
-		case "tag":
-			// add build tag to list of repo tags
-			p.Repo.Tags = append(p.Repo.Tags, p.Build.Tag)
-		default:
-			// add build sha to list of repo tags
-			p.Repo.Tags = append(p.Repo.Tags, p.Build.Sha)
-		}
+		p.Repo.ConfigureAutoTag(p.Build)
 	}
 
 	// validate the plugin

--- a/cmd/vela-kaniko/plugin.go
+++ b/cmd/vela-kaniko/plugin.go
@@ -77,19 +77,6 @@ func (p *Plugin) Command() *exec.Cmd {
 	// add flag for context from provided image context
 	flags = append(flags, fmt.Sprintf("--context=%s", p.Image.Context))
 
-	// check if repo auto tagging is enabled
-	if p.Repo.AutoTag {
-		// check what build event was provided
-		switch p.Build.Event {
-		case "tag":
-			// add build tag to list of repo tags
-			p.Repo.Tags = append(p.Repo.Tags, p.Build.Tag)
-		default:
-			// add build sha to list of repo tags
-			p.Repo.Tags = append(p.Repo.Tags, p.Build.Sha)
-		}
-	}
-
 	// iterate through all repo tags
 	for _, tag := range p.Repo.Tags {
 		// add flag for tag from provided repo tag

--- a/cmd/vela-kaniko/plugin_test.go
+++ b/cmd/vela-kaniko/plugin_test.go
@@ -543,6 +543,44 @@ func TestDocker_Plugin_Validate_NoBuild(t *testing.T) {
 	}
 }
 
+func TestDocker_Plugin_Validate_AutoTag_InvalidBuildTag(t *testing.T) {
+	// setup types
+	p := &Plugin{
+		Build: &Build{
+			Event: "push",
+			Sha:   "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			Tag:   "-v0.0.0",
+		},
+		Image: &Image{
+			Args:       []string{"foo=bar"},
+			Context:    ".",
+			Dockerfile: "Dockerfile",
+			Target:     "",
+		},
+		Registry: &Registry{
+			Name:     "index.docker.io",
+			Username: "octocat",
+			Password: "superSecretPassword",
+			DryRun:   false,
+		},
+		Repo: &Repo{
+			Cache:     true,
+			CacheName: "index.docker.io/target/vela-kaniko",
+			Name:      "index.docker.io/target/vela-kaniko",
+			Tags:      []string{"latest"},
+			AutoTag:   true,
+		},
+	}
+
+	// configure auto_tag using the invalid build tag
+	p.Repo.ConfigureAutoTag(p.Build)
+
+	err := p.Validate()
+	if err == nil {
+		t.Errorf("Validate should have returned err")
+	}
+}
+
 func TestDocker_Plugin_Validate_NoImage(t *testing.T) {
 	// setup types
 	p := &Plugin{

--- a/cmd/vela-kaniko/plugin_test.go
+++ b/cmd/vela-kaniko/plugin_test.go
@@ -128,6 +128,68 @@ func TestDocker_Plugin_Command(t *testing.T) {
 		"--cache-repo=index.docker.io/target/vela-kaniko",
 		"--context=.",
 		"--destination=index.docker.io/target/vela-kaniko:latest",
+		"--dockerfile=Dockerfile",
+		"--no-push",
+		"--push-retry=1",
+		"--target=foo",
+		"--insecure-registry=insecure.docker.local",
+		"--insecure-registry=docker.local",
+		"--insecure-pull",
+		"--insecure",
+		"--verbosity=info",
+	)
+
+	// run test
+	got := p.Command()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Command is %v, want %v", got, want)
+	}
+}
+
+func TestDocker_Plugin_Command_AutoTag(t *testing.T) {
+	// setup types
+	p := &Plugin{
+		Build: &Build{
+			Event: "tag",
+			Sha:   "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			Tag:   "v0.0.0",
+		},
+		Image: &Image{
+			Args:       []string{"foo=bar"},
+			Context:    ".",
+			Dockerfile: "Dockerfile",
+			Target:     "foo",
+		},
+		Registry: &Registry{
+			Name:               "index.docker.io",
+			Username:           "octocat",
+			Password:           "superSecretPassword",
+			DryRun:             true,
+			PushRetry:          1,
+			InsecureRegistries: []string{"insecure.docker.local", "docker.local"},
+			InsecurePull:       true,
+			InsecurePush:       true,
+		},
+		Repo: &Repo{
+			Cache:     true,
+			CacheName: "index.docker.io/target/vela-kaniko",
+			Name:      "index.docker.io/target/vela-kaniko",
+			Tags:      []string{"latest"},
+			AutoTag:   true,
+		},
+	}
+
+	// configure repo tags using auto_tag and build info
+	p.Repo.ConfigureAutoTagBuildTags(p.Build)
+
+	want := exec.Command(
+		kanikoBin,
+		"--build-arg=foo=bar",
+		"--cache",
+		"--cache-repo=index.docker.io/target/vela-kaniko",
+		"--context=.",
+		"--destination=index.docker.io/target/vela-kaniko:latest",
 		"--destination=index.docker.io/target/vela-kaniko:v0.0.0",
 		"--dockerfile=Dockerfile",
 		"--no-push",
@@ -575,7 +637,7 @@ func TestDocker_Plugin_Validate_AutoTag_InvalidBuildTag(t *testing.T) {
 	}
 
 	// configure auto_tag using the invalid build tag
-	p.Repo.ConfigureAutoTag(p.Build)
+	p.Repo.ConfigureAutoTagBuildTags(p.Build)
 
 	err := p.Validate()
 	if err == nil {

--- a/cmd/vela-kaniko/plugin_test.go
+++ b/cmd/vela-kaniko/plugin_test.go
@@ -547,9 +547,10 @@ func TestDocker_Plugin_Validate_AutoTag_InvalidBuildTag(t *testing.T) {
 	// setup types
 	p := &Plugin{
 		Build: &Build{
-			Event: "push",
-			Sha:   "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
-			Tag:   "-v0.0.0",
+			Event:        "tag",
+			Sha:          "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			Tag:          "-v0.0.0",
+			SnapshotMode: "full",
 		},
 		Image: &Image{
 			Args:       []string{"foo=bar"},
@@ -569,6 +570,7 @@ func TestDocker_Plugin_Validate_AutoTag_InvalidBuildTag(t *testing.T) {
 			Name:      "index.docker.io/target/vela-kaniko",
 			Tags:      []string{"latest"},
 			AutoTag:   true,
+			Label:     &Label{},
 		},
 	}
 

--- a/cmd/vela-kaniko/repo.go
+++ b/cmd/vela-kaniko/repo.go
@@ -62,7 +62,7 @@ func (r *Repo) AddLabels() []string {
 	}
 }
 
-// ConfigureAutoTag adds the build tag to repo tags
+// ConfigureAutoTag adds the build tag to repo tags.
 func (r *Repo) ConfigureAutoTag(b *Build) {
 	// check what build event was provided
 	switch b.Event {

--- a/cmd/vela-kaniko/repo.go
+++ b/cmd/vela-kaniko/repo.go
@@ -62,6 +62,19 @@ func (r *Repo) AddLabels() []string {
 	}
 }
 
+// ConfigureAutoTag adds the build tag to repo tags
+func (r *Repo) ConfigureAutoTag(b *Build) {
+	// check what build event was provided
+	switch b.Event {
+	case "tag":
+		// add build tag to list of repo tags
+		r.Tags = append(r.Tags, b.Tag)
+	default:
+		// add build sha to list of repo tags
+		r.Tags = append(r.Tags, b.Sha)
+	}
+}
+
 // Validate verifies the Repo is properly configured.
 func (r *Repo) Validate() error {
 	logrus.Trace("validating repo plugin configuration")

--- a/cmd/vela-kaniko/repo.go
+++ b/cmd/vela-kaniko/repo.go
@@ -62,8 +62,8 @@ func (r *Repo) AddLabels() []string {
 	}
 }
 
-// ConfigureAutoTag adds the build tag to repo tags.
-func (r *Repo) ConfigureAutoTag(b *Build) {
+// ConfigureAutoTagBuildTags adds the build tag to repo tags.
+func (r *Repo) ConfigureAutoTagBuildTags(b *Build) {
 	// check what build event was provided
 	switch b.Event {
 	case "tag":


### PR DESCRIPTION
this PR makes the following changes:
- remove validation from the build tag produced by the user 
    - users should be able to provide whatever tag they wish. 
- move `auto_tag` functionality to the plugin preparation, prior to producing the `Command` used by the kaniko binary.
- fixes up tests

the build tag should only be validated when the user attempts to use it via `auto_tag` to publish

therefore, we should look for `auto_tag` when preparing the plugin configurations, use it to configure the repo tags, _then_ validate those repo tags 

(most of which we are already doing, just out of order) 

closes https://github.com/go-vela/community/issues/701