### PR TITLE
fix: change snapshotMode to snapshot-mode

### DIFF
--- a/cmd/vela-kaniko/plugin.go
+++ b/cmd/vela-kaniko/plugin.go
@@ -50,7 +50,7 @@ func (p *Plugin) Command() *exec.Cmd {
 
 	// check if the snapshot mode is set
 	if len(p.Build.SnapshotMode) != 0 {
-		flags = append(flags, fmt.Sprintf("--snapshotMode=%s", p.Build.SnapshotMode))
+		flags = append(flags, fmt.Sprintf("--snapshot-mode=%s", p.Build.SnapshotMode))
 	}
 
 	if p.Build.UseNewRun {

--- a/cmd/vela-kaniko/plugin_test.go
+++ b/cmd/vela-kaniko/plugin_test.go
@@ -359,7 +359,7 @@ func TestDocker_Plugin_Command_With_SnapshotMode(t *testing.T) {
 
 	want := exec.Command(
 		kanikoBin,
-		"--snapshotMode=redo",
+		"--snapshot-mode=redo",
 		"--build-arg=foo=bar",
 		"--cache",
 		"--cache-repo=index.docker.io/target/vela-kaniko",


### PR DESCRIPTION
Kaniko deprecated the --snapshotMode flag in favor of --snapshot-mode.  This change gets rid of the warning ```level=warning msg="Flag --snapshotMode is deprecated. Use: --snapshot-mode"``` in current release.