### PR TITLE
chore(ci/go): update ci to use core repos pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v4
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
+        check-latest: true
 
     - name: build
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,14 +11,21 @@ on:
 jobs:
   prerelease:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+
     steps:
     - name: clone
       uses: actions/checkout@v3
       with:
         # ensures we fetch tag history for the repository
         fetch-depth: 0
+
+    - name: install go
+      uses: actions/setup-go@v4
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
+        check-latest: true
 
     - name: setup
       run: |
@@ -33,7 +40,7 @@ jobs:
         make build-static-ci
 
     - name: publish
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: target/vela-kaniko
         cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,14 +10,21 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+
     steps:
     - name: clone
       uses: actions/checkout@v3
       with:
         # ensures we fetch tag history for the repository
         fetch-depth: 0
+
+    - name: install go
+      uses: actions/setup-go@v4
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
+        check-latest: true
 
     - name: build
       env:
@@ -27,7 +34,7 @@ jobs:
         make build-static-ci
 
     - name: publish
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: target/vela-kaniko
         cache: true

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,11 +9,18 @@ on:
 jobs:
   diff-review:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v4
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
+        check-latest: true
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v2
@@ -26,11 +33,18 @@ jobs:
 
   full-review:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v4
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
+        check-latest: true
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v4
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
+        check-latest: true
 
     - name: test
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,11 +10,18 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v4
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
+        check-latest: true
 
     - name: validate
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-vela/vela-kaniko
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
using same pattern as we do on core repos: see https://github.com/go-vela/server/tree/main/.github/workflows for example