### PR TITLE
enhance: add arg for third party integration credentials

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -208,9 +208,9 @@ steps:
 The plugin accepts the following files for authentication:
 
 | Parameter  | Volume Configuration                                                |
-| ---------- | ------------------------------------------------------------------- |
-| `password` | `/vela/parameters/kaniko/password`, `/vela/secrets/kaniko/password` |
-| `username` | `/vela/parameters/kaniko/username`, `/vela/secrets/kaniko/username` |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| `password` | `/vela/parameters/kaniko/password`, `/vela/secrets/kaniko/password`, `/vela/secrets/managed-auth/password` |
+| `username` | `/vela/parameters/kaniko/username`, `/vela/secrets/kaniko/username`, `/vela/secrets/managed-auth/username` |
 
 Users can use [Vela external secrets](https://go-vela.github.io/docs/concepts/pipeline/secrets/origin/) to substitute these sensitive values at runtime:
 

--- a/cmd/vela-kaniko/main.go
+++ b/cmd/vela-kaniko/main.go
@@ -173,13 +173,13 @@ func main() {
 		},
 		&cli.StringFlag{
 			EnvVars:  []string{"PARAMETER_USERNAME", "KANIKO_USERNAME", "DOCKER_USERNAME"},
-			FilePath: "/vela/parameters/kaniko/username,/vela/secrets/kaniko/username",
+			FilePath: "/vela/parameters/kaniko/username,/vela/secrets/kaniko/username,/vela/secrets/managed-auth/username",
 			Name:     "registry.username",
 			Usage:    "user name for communication with the registry",
 		},
 		&cli.StringFlag{
 			EnvVars:  []string{"PARAMETER_PASSWORD", "KANIKO_PASSWORD", "DOCKER_PASSWORD"},
-			FilePath: "/vela/parameters/kaniko/password,/vela/secrets/kaniko/password",
+			FilePath: "/vela/parameters/kaniko/password,/vela/secrets/kaniko/password,/vela/secrets/managed-auth/password",
 			Name:     "registry.password",
 			Usage:    "password for communication with the registry",
 		},


### PR DESCRIPTION
support for a third-party integration that writes shared credentials to the managed-auth filepath.
