### PR TITLE
enhance: use chainguard kaniko fork source code for executor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,43 @@ FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff45
 
 RUN apk add --update --no-cache ca-certificates
 
+#########################################################################
+##    Build Kaniko executor from Chainguard source                     ##
+#########################################################################
+
+FROM golang:1.24 as kaniko-builder
+
+WORKDIR /go/src/github.com/chainguard-dev/kaniko
+
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ARG KANIKO_VERSION=v1.25.0
+RUN git clone --depth 1 --branch ${KANIKO_VERSION} https://github.com/chainguard-dev/kaniko.git .
+
+ENV CGO_ENABLED=0
+ENV GOBIN=/usr/local/bin
+
+RUN CGO_ENABLED=0 make out/executor
+
 ##########################################################
 ##    docker build --no-cache -t vela-kaniko:local .    ##
 ##########################################################
 
-FROM gcr.io/kaniko-project/executor:v1.23.2-debug@sha256:c3109d5926a997b100c4343944e06c6b30a6804b2f9abe0994d3de6ef92b028e
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=kaniko-builder /go/src/github.com/chainguard-dev/kaniko/out/executor /kaniko/executor
+
+RUN mkdir -p /workspace /kaniko/.docker /kaniko/ssl/certs && \
+    chmod 777 /workspace /kaniko /kaniko/.docker
+
+ENV HOME /root
+ENV USER root
+ENV PATH /usr/local/bin:/kaniko
+ENV SSL_CERT_DIR /kaniko/ssl/certs
+ENV DOCKER_CONFIG /kaniko/.docker
+
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /kaniko/ssl/certs/ca-certificates.crt
 
 WORKDIR /workspace
 


### PR DESCRIPTION
https://github.com/chainguard-dev/kaniko seems to be a stable option for kaniko moving forward.

However, according to the fork's README:

> We don't plan on publishing built release artifacts (container images, etc.) publicly, but they are available to Chainguard customers. You're welcome to build these yourself from this repository if you are not a Chainguard customer.

Borrowing some lines from the [deploy Dockerfile](https://github.com/chainguard-dev/kaniko/blob/main/deploy/Dockerfile), this PR aims to build the kaniko executor from a tagged version of the chainguard fork. Open to suggestions on how to make that better.