### PR TITLE
chore(renovate): fix renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,20 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>go-vela/renovate-config"
-  ],
   "customManagers": [
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^\\.github/workflows/prerelease\\.yml$/"
+        "/^\\.github/workflows/prerelease\\.yml$/",
+        "/^\\.github/workflows/publish\\.yml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=github-releases depName=chainguard-forks/kaniko\\s+echo \"KANIKO_VERSION=(?<currentValue>v[0-9.]+)\" >> \\$GITHUB_ENV"
+        "KANIKO_VERSION: (?<currentValue>v[0-9.]+)"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "chainguard-forks/kaniko",
-      "extractVersionTemplate": "^v(?<version>.+)$"
+      "extractVersionTemplate": "^(?<version>.+)$"
     },
     {
       "customType": "regex",
@@ -22,11 +20,23 @@
         "/^Dockerfile$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=github-releases depName=chainguard-forks/kaniko\\s+ARG KANIKO_IMAGE=target/kaniko-executor:debug-(?<currentValue>v[0-9.]+)"
+        "ARG KANIKO_IMAGE=target/kaniko-executor:debug-(?<currentValue>v[0-9.]+)"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "chainguard-forks/kaniko",
-      "extractVersionTemplate": "^v(?<version>.+)$"
+      "extractVersionTemplate": "^(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Makefile$/"
+      ],
+      "matchStrings": [
+        "--build-arg KANIKO_IMAGE=target/kaniko-executor:debug-(?<currentValue>v[0-9.]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "chainguard-forks/kaniko",
+      "extractVersionTemplate": "^(?<version>.+)$"
     }
   ],
   "packageRules": [
@@ -37,7 +47,7 @@
       "matchDepNames": [
         "chainguard-forks/kaniko"
       ],
-      "groupName": "chainguard-forks/kaniko"
+      "groupName": "upstream-kaniko"
     }
   ]
 }

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   prerelease:
     runs-on: ubuntu-latest
+    env:
+      KANIKO_VERSION: v1.24.0
 
     steps:
     - name: clone
@@ -31,9 +33,6 @@ jobs:
       run: |
         # setup git tag in Actions environment
         echo "GITHUB_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-        # define the kaniko version to use
-        # renovate: datasource=github-releases depName=chainguard-forks/kaniko
-        echo "KANIKO_VERSION=v1.24.0" >> $GITHUB_ENV
 
     - name: check if kaniko base image exists
       id: check-kaniko

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      KANIKO_VERSION: v1.24.0
 
     steps:
     - name: clone
@@ -25,12 +27,6 @@ jobs:
         go-version-file: 'go.mod'
         cache: true
         check-latest: true
-
-    - name: setup
-      run: |
-        # define the kaniko version to use
-        # renovate: datasource=github-releases depName=chainguard-forks/kaniko
-        echo "KANIKO_VERSION=v1.24.0" >> $GITHUB_ENV
 
     - name: check if kaniko base image exists
       id: check-kaniko

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@
 ##    docker build --no-cache --target certs -t vela-kaniko:certs .    ##
 #########################################################################
 
-# renovate: datasource=github-releases depName=chainguard-forks/kaniko
 ARG KANIKO_IMAGE=target/kaniko-executor:debug-v1.24.0@sha256:eb0b8b7b41042f494ad76cf5478fcfa2eea93a70479d6ee470c3e04c3174dd9a
 
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS certs


### PR DESCRIPTION
currently kaniko updates are failing. looks like release version extraction was causing some issue. i think this should fix. also, simplified the config a bit.

<img width="800" height="268" alt="image" src="https://github.com/user-attachments/assets/625df14a-dd17-4e34-bdd7-3f0769bd74a5" />
